### PR TITLE
Allows SSM parameters to be pulled recursively

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,8 @@ func New(version string, svc service.Service) *cobra.Command {
 				return
 			}
 
+			recursive, _ := cmd.Flags().GetBool("recursive")
+
 			validArgs := []string{}
 			for _, arg := range args {
 				if arg != "" {
@@ -49,7 +51,7 @@ func New(version string, svc service.Service) *cobra.Command {
 				return
 			}
 
-			err := ssm2env.Collect(svc, os.Stdout, validArgs[0])
+			err := ssm2env.Collect(svc, os.Stdout, validArgs[0], recursive)
 			if err != nil {
 				log.Fatal(err)
 				return
@@ -57,6 +59,7 @@ func New(version string, svc service.Service) *cobra.Command {
 		},
 	}
 
+	rootCmd.PersistentFlags().Bool("recursive", false, "searches the path recursively")
 	rootCmd.PersistentFlags().Bool("verbose", false, "enables verbose output")
 	rootCmd.PersistentFlags().Bool("version", false, "prints the version and exits")
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -16,7 +16,7 @@ type SSMClient interface {
 
 // Service will abstract out calls to AWS
 type Service interface {
-	GetParameters(searchPath string) (map[string]string, error)
+	GetParameters(searchPath string, recursive bool) (map[string]string, error)
 }
 
 // Impl will be the implementation of the Service interface
@@ -41,11 +41,12 @@ func NewFromClient(ssmClient SSMClient) (Service, error) {
 }
 
 // GetParameters fetches all of the parameters under a path into a map
-func (svc *Impl) GetParameters(searchPath string) (map[string]string, error) {
+func (svc *Impl) GetParameters(searchPath string, recursive bool) (map[string]string, error) {
 	params := map[string]string{}
 	getParametersByPathInput := &ssm.GetParametersByPathInput{
 		Path:           aws.String(searchPath),
 		WithDecryption: aws.Bool(true),
+		Recursive:      aws.Bool(recursive),
 	}
 
 	err := svc.SSMClient.GetParametersByPathPages(getParametersByPathInput, func(resp *ssm.GetParametersByPathOutput, lastPage bool) bool {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -23,13 +23,15 @@ var _ = Describe("Utils", func() {
 
 		It("Should properly format a map of key values into env format", func() {
 			paramsMap := map[string]string{
-				"foo": "<value-to-be-quoted>",
-				"bar": "contains a single quote y'all",
-				"baz": "uses multiple* special &characters, y'all",
+				"foo":        "<value-to-be-quoted>",
+				"bar":        "contains a single quote y'all",
+				"baz":        "uses multiple* special &characters, y'all",
+				"nested/foo": "demonstrates recursive sanitization",
 			}
 			paramsEnvString := `FOO='<value-to-be-quoted>'
 BAR='contains a single quote y'"'"'all'
 BAZ='uses multiple* special &characters, y'"'"'all'
+NESTED_FOO='demonstrates recursive sanitization'
 `
 
 			err := utils.EnvFormat(buffer, paramsMap)

--- a/ssm2env.go
+++ b/ssm2env.go
@@ -11,7 +11,7 @@ import (
 
 // Collect retrieves the SSM parameters for the given search path and
 // writes to the writer in env format
-func Collect(svc service.Service, w io.Writer, searchPath string) error {
+func Collect(svc service.Service, w io.Writer, searchPath string, recursive bool) error {
 	var err error
 	if svc == nil {
 		log.Debug("Initializing session")
@@ -21,8 +21,13 @@ func Collect(svc service.Service, w io.Writer, searchPath string) error {
 		}
 	}
 
-	log.Debugf("Getting parameters for search path: %s", searchPath)
-	params, err := svc.GetParameters(searchPath)
+	recursively := ""
+	if recursive {
+		recursively = " recursively"
+	}
+
+	log.Debugf("Getting parameters for search path: %s%s", searchPath, recursively)
+	params, err := svc.GetParameters(searchPath, recursive)
 	if err != nil {
 		return err
 	}

--- a/ssm2env_test.go
+++ b/ssm2env_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Ssm2env", func() {
 	})
 
 	It("Should collect the parameters and write the env formatted bytes to the buffer", func() {
-		err = ssm2env.Collect(svc, buffer, Prefix)
+		err = ssm2env.Collect(svc, buffer, Prefix, false)
 		Expect(err).Should(BeNil())
 
 		ss := strings.Split(buffer.String(), "\n")


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We would like to pull SSM parameters recursively.

## Solution

<!-- How does this change fix the problem? -->

Allows a `--recursive` flag to be provided to search SSM recursively.

## Notes

<!-- Additional notes and information here -->

Usage:

```bash
ssm2env --recursive /aws/service/global-infrastructure
```

It will use the recursive paths as prefixes for the environment variables.  For example,

```plaintext
/prefix/foo
/prefix/bar
/prefix/nested/foo
/prefix/another/bar
```

searched recursively on `/prefix` will become

```bash
FOO=...
BAR=...
NESTED_FOO=...
ANOTHER_BAR=...
```
