### PR TITLE
Uses homebrew for install of ssm2env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,3 +42,4 @@ brews:
     tap:
       owner: shopsmart
       name: homewbrew-tap
+      branch: github/template-cleanup

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,3 +43,4 @@ brews:
       owner: shopsmart
       name: homewbrew-tap
       branch: github/template-cleanup
+      folder: Formula

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,4 +43,4 @@ brews:
       owner: shopsmart
       name: homewbrew-tap
       branch: github/template-cleanup
-      folder: Formula
+    folder: Formula

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,4 +43,5 @@ brews:
       owner: shopsmart
       name: homewbrew-tap
       branch: github/template-cleanup
+      token: '{{ .Env.DEPLOY_TOKEN }}'
     folder: Formula

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,6 +41,6 @@ brews:
   - name: ssm2env
     tap:
       owner: shopsmart
-      name: homewbrew-tap
+      name: homebrew-tap
       branch: github/template-cleanup
     folder: Formula

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,5 +42,4 @@ brews:
     tap:
       owner: shopsmart
       name: homebrew-ssm2env
-      branch: github/template-cleanup
     folder: Formula

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,6 +41,6 @@ brews:
   - name: ssm2env
     tap:
       owner: shopsmart
-      name: homebrew-tap
+      name: homebrew-ssm2env
       branch: github/template-cleanup
     folder: Formula

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,3 +36,9 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+# The Homebrew formula
+brews:
+  - name: ssm2env
+    tap:
+      owner: shopsmart
+      name: homewbrew-tap

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,5 +43,4 @@ brews:
       owner: shopsmart
       name: homewbrew-tap
       branch: github/template-cleanup
-      token: '{{ .Env.DEPLOY_TOKEN }}'
     folder: Formula

--- a/README.md
+++ b/README.md
@@ -2,16 +2,7 @@
 
 ## Installation
 
-### Linux
-
 ```bash
-tar -zxvf <(curl -Lo - https://github.com/shopsmart/ssm2env/releases/download/v1.0.0/ssm2env_1.0.0_linux_amd64.tar.gz) ssm2env
-mv ssm2env /usr/local/bin
-```
-
-### MacOS
-
-```bash
-tar -zxvf <(curl -Lo - https://github.com/shopsmart/ssm2env/releases/download/v1.0.0/ssm2env_1.0.0_darwin_amd64.tar.gz) ssm2env
-mv ssm2env /usr/local/bin
+brew tap shopsmart/homebrew-ssm2env
+brew install ssm2env
 ```


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We would like goreleaser to keep a homebrew recipe up-to-date.

## Solution

<!-- How does this change fix the problem? -->

Adds `brews` to the goreleaser configuration.

## Notes

<!-- Additional notes and information here -->
