### PR TITLE
Updates release workflow to have write permissions on releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - v*
 
+permissions:
+  contents: write # publish release assets
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

The release is failing because the workflow has not been updated since Github added specific permissions to github workflows.

## Solution

<!-- How does this change fix the problem? -->

Adds contents: write permissions to allow the workflow to publish release assets.

## Notes

<!-- Additional notes and information here -->
