### PR TITLE
Sets up homebrew prior to installing bats-core

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,9 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@v2
 
+      - name: 'Setup brew'
+        uses: Homebrew/actions/setup-homebrew@master
+
       - name: 'Install BATS'
         run: brew install bats-core
 


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

The release workflow is broken.

## Solution

<!-- How does this change fix the problem? -->

Sets up homebrew prior to running a brew command.

## Notes

<!-- Additional notes and information here -->
