### PR TITLE
Allows flags to override configurations set by environment

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,16 +77,17 @@ func New(version string, svc service.Service) *cobra.Command {
 		},
 	}
 
-	rootCmd.PersistentFlags().Bool("multiline", true, "enables multiline support; to enable, set --multiline=false")
-	rootCmd.PersistentFlags().Bool("recursive", false, "searches the path recursively")
-	rootCmd.PersistentFlags().Bool("export", false, "adds export before each variable")
-	rootCmd.PersistentFlags().Bool("verbose", false, "enables verbose output")
-	rootCmd.PersistentFlags().Bool("version", false, "prints the version and exits")
+	rootCmd.Flags().Bool("multiline", true, "enables multiline support; to enable, set --multiline=false")
+	rootCmd.Flags().Bool("recursive", false, "searches the path recursively")
+	rootCmd.Flags().Bool("export", false, "adds export before each variable")
+	rootCmd.Flags().Bool("verbose", false, "enables verbose output")
+	rootCmd.Flags().Bool("version", false, "prints the version and exits")
 
 	_ = config.BindPFlag("multiline", rootCmd.Flags().Lookup("multiline"))
 	_ = config.BindPFlag("recursive", rootCmd.Flags().Lookup("recursive"))
 	_ = config.BindPFlag("export", rootCmd.Flags().Lookup("export"))
 	_ = config.BindPFlag("verbose", rootCmd.Flags().Lookup("verbose"))
+	_ = config.BindPFlag("version", rootCmd.Flags().Lookup("version"))
 
 	_ = config.BindEnv("path")
 	_ = config.BindEnv("multiline")

--- a/tests/integration.bats
+++ b/tests/integration.bats
@@ -29,8 +29,38 @@ function teardown() {
 
   [ $status -eq 0 ]
 
-  echo "$output"
-
   echo "$output" | sort > "$BATS_TEST_TMPDIR/ssm2env.env"
   diff -y "$BATS_TEST_DIRNAME/expected.env" "$BATS_TEST_TMPDIR/ssm2env.env"
+}
+
+@test "it should export the ssm params if the --export flag is provided" {
+  run "$TEST_SSM2ENV_EXECUTABLE" --export /aws/service/global-infrastructure/regions
+
+  [ $status -eq 0 ]
+
+  echo "$output" | sort > "$BATS_TEST_TMPDIR/ssm2env.env"
+  sed 's/^/export /' "$BATS_TEST_DIRNAME/expected.env" | sort > "$BATS_TEST_TMPDIR/sorted.env"
+  diff -y "$BATS_TEST_TMPDIR/sorted.env" "$BATS_TEST_TMPDIR/ssm2env.env"
+}
+
+@test "it should export the ssm params if the SSM2ENV_EXPORT variable is set" {
+  run env SSM2ENV_EXPORT=true "$TEST_SSM2ENV_EXECUTABLE" /aws/service/global-infrastructure/regions
+
+  [ $status -eq 0 ]
+
+  echo "$output" | sort > "$BATS_TEST_TMPDIR/ssm2env.env"
+  sed 's/^/export /' "$BATS_TEST_DIRNAME/expected.env" | sort > "$BATS_TEST_TMPDIR/sorted.env"
+  diff -y "$BATS_TEST_TMPDIR/sorted.env" "$BATS_TEST_TMPDIR/ssm2env.env"
+}
+
+# Validate that flags take precedence over environment variables
+
+@test "it should export the ssm params if the SSM2ENV_EXPORT variable is false but the flag is provided" {
+  run env SSM2ENV_EXPORT=false "$TEST_SSM2ENV_EXECUTABLE" --export /aws/service/global-infrastructure/regions
+
+  [ $status -eq 0 ]
+
+  echo "$output" | sort > "$BATS_TEST_TMPDIR/ssm2env.env"
+  sed 's/^/export /' "$BATS_TEST_DIRNAME/expected.env" | sort > "$BATS_TEST_TMPDIR/sorted.env"
+  diff -y "$BATS_TEST_TMPDIR/sorted.env" "$BATS_TEST_TMPDIR/ssm2env.env"
 }


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

When setting an environment variable and using a flag, it pulled either frmo the default or the environment over the flag (hard to tell because booleans only have two values).

## Solution

<!-- How does this change fix the problem? -->

Properly binds the pFlags to allow for flags to overwrite the environment provided configurations.

## Notes

<!-- Additional notes and information here -->

Adds a few integration tests to validate that the flags take precedence over the environment.
