### PR TITLE
Adds a zip release asset that can be run as a lambda layer to auto inject environment variables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,5 +86,6 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
+            dist/*.zip
             dist/*.tar.gz
             dist/checksums.txt

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,9 @@ before:
     # you may remove this if you don't need go generate
     # - go generate ./...
 builds:
-  - env:
+  - &build
+    id: default
+    env:
       - CGO_ENABLED=0
     goos:
       - linux
@@ -19,6 +21,11 @@ builds:
     main: ./cmd/ssm2env
     ldflags:
       - "-X main.version={{ incpatch .Version }}"
+  - <<: *build
+    id: lambda
+    binary: bin/ssm2env
+    goos:
+     - linux
 # archives:
 #   - replacements:
 #       darwin: Darwin
@@ -43,3 +50,17 @@ brews:
       owner: shopsmart
       name: homebrew-ssm2env
     folder: Formula
+    ids:
+      - default
+archives:
+  - builds:
+      - default
+  - id: lambda
+    format: zip
+    builds:
+      - lambda
+    files:
+      - src: lambda/extensions/*
+        dst: extensions/
+        strip_parent: true
+    name_template: "{{ .ProjectName }}-lambda-layer_{{ .Version }}_{{ .Os }}_{{ .Arch }}"

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -1,0 +1,17 @@
+# SSM2ENV Lambda Layer
+
+We can create an ssm2env lambda layer which will run the ssm2env cli to export all environment variables into the lambda prior to the actual lambda being run.  This will use the `SSM2ENV_PATH` environment variable to determine where to pull variables from.  All `SSM2ENV_` environment variables can be set to configure the cli *except* export which is necessary for the layer to work.
+
+To make use of this layer, simply create a lambda layer for each architecture and upload the provided release zips as the source.  In the future, it would be nice to see this as a public layer for consumption, but for now, it will be dependent on the consumer of this layer to create the layer themselves.
+
+```bash
+gh release download -R shopsmart/ssm2env -p 'ssm2env-lambda-layer_*.zip' -D lambda
+
+aws lambda publish-layer-version --layer-name "ssm2env-amd64" \
+  -compatible-architectures x86_64 \
+  --zip-file lambda/ssm2env-lambda-layer_*_linux_amd64.zip
+
+aws lambda publish-layer-version --layer-name "ssm2env-arm64" \
+  -compatible-architectures arm64 \
+  --zip-file lambda/ssm2env-lambda-layer_*_linux_arm64.zip
+```

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -2,7 +2,7 @@
 
 We can create an ssm2env lambda layer which will run the ssm2env cli to export all environment variables into the lambda prior to the actual lambda being run.  This will use the `SSM2ENV_PATH` environment variable to determine where to pull variables from.  All `SSM2ENV_` environment variables can be set to configure the cli *except* export which is necessary for the layer to work.
 
-To make use of this layer, simply create a lambda layer for each architecture and upload the provided release zips as the source.  In the future, it would be nice to see this as a public layer for consumption, but for now, it will be dependent on the consumer of this layer to create the layer themselves.
+To make use of this layer, simply create a lambda layer for the desired architecture or both and upload the provided release zips as the source.  In the future, it would be nice to see this as a public layer for consumption, but for now, it will be dependent on the consumer of this layer to create the layer themselves.
 
 ```bash
 gh release download -R shopsmart/ssm2env -p 'ssm2env-lambda-layer_*.zip' -D lambda

--- a/lambda/extensions/pull-ssm-parameters.sh
+++ b/lambda/extensions/pull-ssm-parameters.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "[DEBUG] ssm2env layer start" >&2
+
+if [ -z "${SSM2ENV_PATH:-}" ]; then
+  echo "[INFO ] No ssm2env path provided" >&2
+  exit 0
+fi
+
+echo "[INFO ] Pulling ssm parameters from $SSM2ENV_PATH" >&2
+eval "$(ssm2env --export "$SSM2ENV_PATH")"
+
+echo "[DEBUG] ssm2env layer end" >&2


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We would like to run ssm2env as a lambda layer to auto inject environment variables before a lambda is run.

## Solution

<!-- How does this change fix the problem? -->

- Adds a shell script extension to inject environment variables from ssm2env.
- Adds a release artifact which is the packaged lambda layer.

## Notes

<!-- Additional notes and information here -->

I would like to see this as a public layer in the future, but for now, we will require consumers to create their own layers for consumption.  In the future, we can expose a layer for public consumption but would require a bit of setup

## Usage

To consume this layer (after creating it within the respective account), simply add it as a layer to your lambda and set the desired ssm2env configurations as static environment variables where `SSM2ENV_PATH` is required to actually get the variables; otherwise, it will do nothing.



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204006614651154